### PR TITLE
Fix wrong y offset for the median line

### DIFF
--- a/src/components/MedianLine.js
+++ b/src/components/MedianLine.js
@@ -25,7 +25,7 @@ class MedianLine extends Component {
               line = d3.line()([[0, 5],
                                 [this.props.width, 5]]);
 
-        const translate = `translate(${this.props.x}, ${this.yScale(median)})`,
+        const translate = `translate(${this.props.x}, ${this.yScale(median) + this.props.y})`,
               medianLabel = `Median Household: $${this.yScale.tickFormat()(median)}`;
 
         return (

--- a/src/components/MedianLine.js
+++ b/src/components/MedianLine.js
@@ -25,7 +25,7 @@ class MedianLine extends Component {
               line = d3.line()([[0, 5],
                                 [this.props.width, 5]]);
 
-        const translate = `translate(${this.props.x}, ${this.yScale(median) + this.props.y})`,
+        const translate = `translate(${this.props.x}, ${this.yScale(median) + this.props.y - 5})`,
               medianLabel = `Median Household: $${this.yScale.tickFormat()(median)}`;
 
         return (


### PR DESCRIPTION
I was following the "Make it understandable - meta info" section and, as expected, the median household salary line appeared in my histogram, at what it looked like the right place.

Except that it shouldn't have been at the right place since in your example you draw the line offset by 5px "to allow room for the label":

```js
const line = d3.line()([[0, 5], [this.props.width, 5]]);`
```

So I went on trying to understand why something that's not supposed to work was actually working. A classic 😅. Turns out the histogram is drawn with a Y offset of 10px to allow for the ticks to be visible, but that same offset is not used for the median line:

Histogram.js uses props.y:
```js
const translate = `translate(${this.props.x}, ${this.props.y})`;
```

MedianLine.js doesn't, but it should:
```js
- const translate = `translate(${this.props.x}, ${this.yScale(median)})`;
+ const translate = `translate(${this.props.x}, ${this.yScale(median) + this.props.y - 5})`;
```